### PR TITLE
Simplify fast_bundler binary

### DIFF
--- a/bin/fast_bundler
+++ b/bin/fast_bundler
@@ -8,22 +8,10 @@ require 'bundler'
 module Bundler
   class Source
     class Rubygems
-      API_REQUEST_LIMIT = 1000
+      remove_const :API_REQUEST_LIMIT
+      const_set :API_REQUEST_LIMIT, 1000
     end
   end
 end
-# Check if an older version of bundler is installed
-$LOAD_PATH.each do |path|
-  if path =~ %r'/bundler-0.(\d+)' && $1.to_i < 9
-    err = "Looks like you have a version of bundler that's older than 0.9.\n"
-    err << "Please remove your old versions.\n"
-    err << "An easy way to do this is by running `gem cleanup bundler`."
-    abort(err)
-  end
-end
 
-require 'bundler/friendly_errors'
-Bundler.with_friendly_errors do
-  require 'bundler/cli'
-  Bundler::CLI.start(ARGV, :debug => true)
-end
+load Gem.bin_path('bundler', 'bundler')


### PR DESCRIPTION
- do not copy content of bundler's bin
- do not warn about constant redefinition
