### PR TITLE
add bin/fast_bundle as an alias of bin/fast_bundler

### DIFF
--- a/bin/fast_bundle
+++ b/bin/fast_bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+exec Gem.bin_path('fast_bundler', 'fast_bundler')


### PR DESCRIPTION
so you can run `fast_bundle` as well as `fast_bundler`
because you run `bundle` instead of `bundler`
